### PR TITLE
Update README to reflect renaming alpha_strength to point_strength

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The following options are available (shown with their default values):
 ```python
 heatmapper = Heatmapper(
     point_diameter=50,  # the size of each point to be drawn
-    alpha_strength=0.2,  # the strength, between 0 and 1, of each point to be drawn
+    point_strength=0.2,  # the strength, between 0 and 1, of each point to be drawn
     opacity=0.65,  # the opacity of the heatmap layer
     colours='default',  # 'default' or 'reveal'
                         # OR a matplotlib LinearSegmentedColorMap object 


### PR DESCRIPTION
README.md is out of date since the following commit a8a8611927492b5ceb2417689bb30b892de767bf

This closes #2